### PR TITLE
Add --ignore-resource-errors switch to hide resource errors from output

### DIFF
--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -71,8 +71,9 @@ program
   .option('-s, --setting <key>=<value>', 'specify specific phantom settings', setting)
   .option('-v, --view <width>x<height>', 'specify phantom viewport size', viewport)
   .option('-C, --no-color',              'disable color escape codes')
-  .option('-p, --path <path>',           'path to PhantomJS binary');
-
+  .option('-p, --path <path>',           'path to PhantomJS binary')
+  .option('-i, --no-reserrors',          'hide resource errors');
+  
 program.on('--help', function(){
   console.log('  Examples:');
   console.log('');
@@ -107,7 +108,8 @@ var config = JSON.stringify({
   viewportSize: program.view,
   useColors: program.color,
   bail: program.bail,
-  file: program.file
+  file: program.file,
+  showResourceErrors: program.reserrors
 });
 
 if (reporter) {

--- a/bin/mocha-phantomjs
+++ b/bin/mocha-phantomjs
@@ -72,7 +72,7 @@ program
   .option('-v, --view <width>x<height>', 'specify phantom viewport size', viewport)
   .option('-C, --no-color',              'disable color escape codes')
   .option('-p, --path <path>',           'path to PhantomJS binary')
-  .option('-i, --no-reserrors',          'hide resource errors');
+  .option('--ignore-resource-errors',    'ignore resource errors');
   
 program.on('--help', function(){
   console.log('  Examples:');
@@ -109,7 +109,7 @@ var config = JSON.stringify({
   useColors: program.color,
   bail: program.bail,
   file: program.file,
-  showResourceErrors: program.reserrors
+  ignoreResourceErrors: program.ignoreResourceErrors
 });
 
 if (reporter) {

--- a/lib/mocha-phantomjs.coffee
+++ b/lib/mocha-phantomjs.coffee
@@ -45,7 +45,7 @@ class Reporter
     @page.viewportSize = @config.viewportSize if @config.viewportSize
     @page.onConsoleMessage = (msg) -> system.stdout.writeLine(msg)
     @page.onResourceError = (resErr) =>
-      if @config.showResourceErrors
+      if !@config.ignoreResourceErrors
         system.stdout.writeLine "Error loading resource #{resErr.url} (#{resErr.errorCode}). Details: #{resErr.errorString}" 
     @page.onError = (msg, traces) =>
       return if @page.evaluate -> window.onerror?

--- a/lib/mocha-phantomjs.coffee
+++ b/lib/mocha-phantomjs.coffee
@@ -44,8 +44,9 @@ class Reporter
     @page.addCookie(cookie) for cookie in @config.cookies or []
     @page.viewportSize = @config.viewportSize if @config.viewportSize
     @page.onConsoleMessage = (msg) -> system.stdout.writeLine(msg)
-    @page.onResourceError = (resErr) ->
-      system.stdout.writeLine "Error loading resource #{resErr.url} (#{resErr.errorCode}). Details: #{resErr.errorString}"
+    @page.onResourceError = (resErr) =>
+      if @config.showResourceErrors
+        system.stdout.writeLine "Error loading resource #{resErr.url} (#{resErr.errorCode}). Details: #{resErr.errorString}" 
     @page.onError = (msg, traces) =>
       return if @page.evaluate -> window.onerror?
       for {line, file}, index in traces


### PR DESCRIPTION
This fixes #153 by adding an --ignore-resource-errors switch to hide resource errors.