### PR TITLE
include comment about special character encoding in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Your HTML file's structure should look something like this. The reporter set bel
 <html>
   <head>
     <meta charset="utf-8">
+    <!-- encoding must be set for mocha's special characters to render properly -->
     <link rel="stylesheet" href="mocha.css" />
   </head>
   <body>


### PR DESCRIPTION
This makes the answer to the problem articulated in issue #60 a little more explicit in the documentation. It is not actually OSX specific, I was making myself nuts trying to figure out why this was happening on my Linux box until I poked around in the closed issues and realized my oversight.

Thanks for making such a useful tool!