### PR TITLE
Update console.log to work with circula reference object

### DIFF
--- a/lib/mocha-phantomjs/core_extensions.js
+++ b/lib/mocha-phantomjs/core_extensions.js
@@ -25,7 +25,12 @@
     if (typeof f !== 'string') {
       var objects = [];
       for (var i = 0; i < arguments.length; i++) {
-        objects.push(JSON.stringify(arguments[i]));
+        try {
+          objects.push(JSON.stringify(arguments[i]));
+        }
+        catch (_) {
+          objects.push('[Circular]');
+        }
       }
       return objects.join(' ');
     }
@@ -38,7 +43,12 @@
       switch (x) {
         case '%s': return String(args[i++]);
         case '%d': return Number(args[i++]);
-        case '%j': return JSON.stringify(args[i++]);
+        case '%j':
+          try {
+            return JSON.stringify(args[i++]);
+          } catch (_) {
+            return '[Circular]';
+          }
         default:
           return x;
       }

--- a/test/console-log.html
+++ b/test/console-log.html
@@ -1,0 +1,26 @@
+<html>
+  <head>
+    <title>Tests Passing</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script>
+      mocha.ui('bdd');
+      mocha.reporter('html');
+      expect = chai.expect;
+    </script>
+    <script src="lib/console-log.js"></script>
+    <script>
+      if (window.mochaPhantomJS) {
+        mochaPhantomJS.run();
+      } else {
+        mocha.run();
+      }
+    </script>
+  </body>
+</html>
+

--- a/test/lib/console-log.js
+++ b/test/lib/console-log.js
@@ -1,0 +1,10 @@
+expect = (chai && chai.expect) || require('chai').expect;
+
+describe('Tests Passing', function() {
+  it('passes 1', function() {
+    var o = {};
+    o['self'] = o;
+
+    console.log(o);
+  });
+});

--- a/test/mocha-phantomjs.coffee
+++ b/test/mocha-phantomjs.coffee
@@ -71,6 +71,11 @@ describe 'mocha-phantomjs', ->
       expect(stdout).to.not.match /Failed to load the page\./m
       expect(code).to.equal 0
 
+  it 'does not fail when console.log is used with circular reference object', (done) ->
+    @runner done, [fileURL('console-log')], (code, stdout, stderr) ->
+      expect(stdout).to.not.match /cannot serialize cyclic structures\./m
+      expect(code).to.equal 0
+
   it 'returns the mocha runner from run() and allows modification of it', (done) ->
     @runner done, [fileURL('mocha-runner')], (code, stdout, stderr) ->
       expect(stdout).to.not.match /Failed via an Event/m


### PR DESCRIPTION
I found a small bug when mocha-phantomjs reports test as failed while passed in browser. It turns out that i was using console.log to print out a circular object, and mocha-phantomjs console.log function fails to handle that. The bug can be illustrated as follow

```javascript
var o = {};
o['self'] = o;

console.log(o);
```

This pull request fixed the bug and also add a unit test to cover that bug.

I hope this will be merged soon!